### PR TITLE
make ctrl-d quit (just like ctrl-c)

### DIFF
--- a/cmd/gpterm/cmd/exp/altscreen.go
+++ b/cmd/gpterm/cmd/exp/altscreen.go
@@ -58,7 +58,7 @@ func (m altScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.ready = true
 	case tea.KeyMsg:
 		switch msg.Type {
-		case tea.KeyCtrlC:
+		case tea.KeyCtrlC, tea.KeyCtrlD:
 			return m, tea.Quit
 		case tea.KeyCtrlG:
 			m.alt = !m.alt

--- a/cmd/gpterm/cmd/exp/scroll.go
+++ b/cmd/gpterm/cmd/exp/scroll.go
@@ -97,7 +97,7 @@ func (m scroller) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch msg.Type {
-		case tea.KeyCtrlC:
+		case tea.KeyCtrlC, tea.KeyCtrlD:
 			return m, tea.Quit
 		}
 	}

--- a/cmd/gpterm/cmd/exp/scrollback.go
+++ b/cmd/gpterm/cmd/exp/scrollback.go
@@ -41,7 +41,7 @@ func (m scrollback) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Sequence(tea.ClearScreen)
 	case tea.KeyMsg:
 		switch msg.Type {
-		case tea.KeyCtrlC:
+		case tea.KeyCtrlC, tea.KeyCtrlD:
 			return m, tea.Quit
 		}
 	}

--- a/lib/ui/control.go
+++ b/lib/ui/control.go
@@ -248,7 +248,7 @@ func (m controlModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.Type {
 
-		case tea.KeyCtrlC:
+		case tea.KeyCtrlC, tea.KeyCtrlD:
 			return m, tea.Quit
 
 		case tea.KeyF1:


### PR DESCRIPTION
tiny change, pretty much what it says on the tin

I manually tested the change in `lib/ui/control.go` but I wasn't sure about the others. They might be wrong and I'm happy to revert.